### PR TITLE
feat(castor): add capacity so you can create and resolve prism dids with ed25519 and x25519 keys

### DIFF
--- a/EdgeAgentSDK/Castor/Sources/DID/PrismDID/PrismDIDPublicKey.swift
+++ b/EdgeAgentSDK/Castor/Sources/DID/PrismDID/PrismDIDPublicKey.swift
@@ -61,12 +61,14 @@ struct PrismDIDPublicKey {
 
     let apollo: Apollo
     let id: String
+    let curve: String
     let usage: Usage
     let keyData: PublicKey
 
-    init(apollo: Apollo, id: String, usage: Usage, keyData: PublicKey) {
+    init(apollo: Apollo, id: String, curve: String, usage: Usage, keyData: PublicKey) {
         self.apollo = apollo
         self.id = id
+        self.curve = curve
         self.usage = usage
         self.keyData = keyData
     }
@@ -77,20 +79,22 @@ struct PrismDIDPublicKey {
         usage = proto.usage.fromProto()
         switch proto.keyData {
         case let .ecKeyData(value):
+            curve = value.curve.lowercased()
             keyData = try apollo.createPublicKey(parameters: [
                 KeyProperties.type.rawValue: "EC",
-                KeyProperties.curve.rawValue: "secp256k1",
+                KeyProperties.curve.rawValue: value.curve.lowercased(),
                 KeyProperties.curvePointX.rawValue: value.x.base64EncodedString(),
                 KeyProperties.curvePointY.rawValue: value.y.base64EncodedString()
             ])
         case let .compressedEcKeyData(value):
+            curve = value.curve.lowercased()
             keyData = try apollo.createPublicKey(parameters: [
                 KeyProperties.type.rawValue: "EC",
-                KeyProperties.curve.rawValue: "secp256k1",
+                KeyProperties.curve.rawValue: value.curve.lowercased(),
                 KeyProperties.rawKey.rawValue: value.data.base64EncodedString()
             ])
         default:
-            throw CastorError.invalidPublicKeyCoding(didMethod: "prism", curve: "secp256k1")
+            throw CastorError.invalidPublicKeyCoding(didMethod: "prism", curve: "")
         }
     }
 
@@ -112,7 +116,7 @@ struct PrismDIDPublicKey {
         var protoEC = Io_Iohk_Atala_Prism_Protos_ECKeyData()
         protoEC.x = pointX
         protoEC.y = pointY
-        protoEC.curve = "secp256k1"
+        protoEC.curve = curve
         protoKey.keyData = .ecKeyData(protoEC)
         return protoKey
     }

--- a/EdgeAgentSDK/Castor/Sources/Operations/CreatePrismDIDOperation.swift
+++ b/EdgeAgentSDK/Castor/Sources/Operations/CreatePrismDIDOperation.swift
@@ -10,16 +10,21 @@ struct CreatePrismDIDOperation {
 
     func compute() throws -> DID {
         var operation = Io_Iohk_Atala_Prism_Protos_AtalaOperation()
+        guard let masterKeyCurve = masterPublicKey.getProperty(.curve) else {
+            throw CastorError.invalidPublicKeyCoding(didMethod: "prism", curve: "no curve")
+        }
         operation.createDid = try createDIDAtalaOperation(
             publicKeys: [PrismDIDPublicKey(
                 apollo: apollo,
                 id: PrismDIDPublicKey.Usage.authenticationKey.defaultId,
+                curve: masterKeyCurve,
                 usage: .authenticationKey,
                 keyData: masterPublicKey
             ),
             PrismDIDPublicKey(
                 apollo: apollo,
                 id: PrismDIDPublicKey.Usage.masterKey.defaultId,
+                curve: masterKeyCurve,
                 usage: .masterKey,
                 keyData: masterPublicKey
             )],

--- a/EdgeAgentSDK/Castor/Tests/PrismDIDPublicKeyTests.swift
+++ b/EdgeAgentSDK/Castor/Tests/PrismDIDPublicKeyTests.swift
@@ -12,7 +12,7 @@ final class PrismDIDPublicKeyTests: XCTestCase {
     override func setUp() async throws {
         apollo = ApolloImpl()
         seed = apollo.createRandomSeed().seed
-        privateKey = try await apollo.createPrivateKey(parameters: [
+        privateKey = try apollo.createPrivateKey(parameters: [
             KeyProperties.type.rawValue: "EC",
             KeyProperties.curve.rawValue: KnownKeyCurves.secp256k1.rawValue,
             KeyProperties.seed.rawValue: seed.value.base64Encoded(),
@@ -23,7 +23,8 @@ final class PrismDIDPublicKeyTests: XCTestCase {
     func testFromProto() throws {
         let publicKey = PrismDIDPublicKey(
             apollo: apollo,
-            id: PrismDIDPublicKey.Usage.masterKey.id(index: 0),
+            id: PrismDIDPublicKey.Usage.masterKey.id(index: 0), 
+            curve: "secp256k1",
             usage: .masterKey,
             keyData: privateKey.publicKey()
         )


### PR DESCRIPTION
### Description: 
Add capacity so you can create and resolve prism dids with ed25519 and x25519 keys

Fixes ATL-7160

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
