### PR TITLE
feat(agent)!: now the agent can process a connectionless presentation request

### DIFF
--- a/EdgeAgentSDK/Castor/Sources/Resolvers/PeerDIDResolver.swift
+++ b/EdgeAgentSDK/Castor/Sources/Resolvers/PeerDIDResolver.swift
@@ -203,7 +203,7 @@ extension DIDCore.DIDDocument.VerificationMethod {
 }
 
 extension DIDCore.DIDDocument.Service {
-    init(from: AnyCodable) throws {
+    init(from: DIDCore.AnyCodable) throws {
         guard
             let dic = from.value as? [String: Any],
             let id = dic["id"] as? String,
@@ -211,7 +211,7 @@ extension DIDCore.DIDDocument.Service {
             let serviceEndpoint = dic["serviceEndpoint"]
         else { throw CommonError.invalidCoding(message: "Could not decode service") }
         switch serviceEndpoint {
-        case let value as AnyCodable:
+        case let value as DIDCore.AnyCodable:
             self = .init(
                 id: id,
                 type: type,
@@ -240,7 +240,7 @@ extension DIDCore.DIDDocument.Service {
         }
     }
 
-    func toAnyCodable() -> AnyCodable {
+    func toAnyCodable() -> DIDCore.AnyCodable {
         AnyCodable(dictionaryLiteral:
             ("id", self.id),
             ("type", self.type),

--- a/EdgeAgentSDK/Domain/Sources/AnyCodable.swift
+++ b/EdgeAgentSDK/Domain/Sources/AnyCodable.swift
@@ -1,27 +1,27 @@
 import Foundation
 
-struct AnyCodable {
-    let value: Any
+public struct AnyCodable {
+    public let value: Any
 
-    init<T: Codable>(_ value: T) {
+    public init<T: Codable>(_ value: T) {
         self.value = value
     }
 
-    init(_ value: Any) {
+    public init(_ value: Any) {
         self.value = value
     }
 
-    func get<T>() -> T? {
+    public func get<T>() -> T? {
         value as? T
     }
 
-    func get() -> Any {
+    public func get() -> Any {
         value
     }
 }
 
 extension AnyCodable: Codable {
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -48,7 +48,7 @@ extension AnyCodable: Codable {
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self.value {
@@ -103,7 +103,7 @@ extension AnyCodable: Codable {
 }
 
 extension AnyCodable: Equatable {
-    static func ==(lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+    public static func ==(lhs: AnyCodable, rhs: AnyCodable) -> Bool {
         switch (lhs.value, rhs.value) {
         case is (Void, Void):
             return true
@@ -146,7 +146,7 @@ extension AnyCodable: Equatable {
 }
 
 extension AnyCodable: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch value {
         case is Void:
             return String(describing: nil as Any?)
@@ -159,7 +159,7 @@ extension AnyCodable: CustomStringConvertible {
 }
 
 extension AnyCodable: CustomDebugStringConvertible {
-    var debugDescription: String {
+    public var debugDescription: String {
         switch value {
         case let value as CustomDebugStringConvertible:
             return "AnyCodable(\(value.debugDescription))"
@@ -171,35 +171,35 @@ extension AnyCodable: CustomDebugStringConvertible {
 
 extension AnyCodable: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral, ExpressibleByStringLiteral, ExpressibleByArrayLiteral, ExpressibleByDictionaryLiteral {
 
-    init(nilLiteral: ()) {
+    public init(nilLiteral: ()) {
         self.init(nil ?? ())
     }
 
-    init(booleanLiteral value: Bool) {
+    public init(booleanLiteral value: Bool) {
         self.init(value)
     }
 
-    init(integerLiteral value: Int) {
+    public init(integerLiteral value: Int) {
         self.init(value)
     }
 
-    init(floatLiteral value: Double) {
+    public init(floatLiteral value: Double) {
         self.init(value)
     }
 
-    init(extendedGraphemeClusterLiteral value: String) {
+    public init(extendedGraphemeClusterLiteral value: String) {
         self.init(value)
     }
 
-    init(stringLiteral value: String) {
+    public init(stringLiteral value: String) {
         self.init(value)
     }
 
-    init(arrayLiteral elements: Any...) {
+    public init(arrayLiteral elements: Any...) {
         self.init(elements)
     }
 
-    init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+    public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
         self.init(Dictionary<AnyHashable, Any>(elements, uniquingKeysWith: { (first, _) in first }))
     }
 }

--- a/EdgeAgentSDK/Domain/Sources/Models/Message+Codable.swift
+++ b/EdgeAgentSDK/Domain/Sources/Models/Message+Codable.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Message: Codable {
     enum CodingKeys: String, CodingKey {
         case id
-        case piuri
+        case piuri = "type"
         case from
         case to
         case fromPrior

--- a/EdgeAgentSDK/Domain/Sources/Models/MessageAttachment.swift
+++ b/EdgeAgentSDK/Domain/Sources/Models/MessageAttachment.swift
@@ -96,12 +96,12 @@ public struct AttachmentLinkData: AttachmentData {
 /// The `AttachmentJsonData` struct represents a DIDComm attachment containing JSON data.
 public struct AttachmentJsonData: AttachmentData {
     /// The JSON data associated with the attachment.
-    public let data: Data
+    public let json: AnyCodable
 
     /// Initializes a new `AttachmentJsonData` object with the specified properties.
     /// - Parameter data: The JSON data associated with the attachment.
-    public init(data: Data) {
-        self.data = data
+    public init(json: AnyCodable) {
+        self.json = json
     }
 }
 

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Invitation/V2/OutOfBandInvitation.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Invitation/V2/OutOfBandInvitation.swift
@@ -27,6 +27,7 @@ public struct OutOfBandInvitation: Decodable {
     public let type = ProtocolTypes.didcomminvitation.rawValue
     public let from: String
     public let body: Body
+    public let attachments: [AttachmentDescriptor]?
 
     /**
      Creates a new `OutOfBandInvitation` object.
@@ -42,11 +43,13 @@ public struct OutOfBandInvitation: Decodable {
     init(
         id: String = UUID().uuidString,
         body: Body,
-        from: DID
+        from: DID,
+        attachments: [AttachmentDescriptor]? = nil
     ) {
         self.id = id
         self.body = body
         self.from = from.string
+        self.attachments = attachments
     }
 }
 

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Pickup/PickupRunner.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Pickup/PickupRunner.swift
@@ -37,7 +37,7 @@ class PickupRunner {
                     else { return nil }
                     return (base64String, attachment.id)
                 case let json as AttachmentJsonData:
-                    return String(data: json.data, encoding: .utf8).map { ($0, attachment.id) }
+                    return (try JSONEncoder.didComm().encode(json.json).tryToString(), attachment.id)
                 default:
                     return nil
                 }

--- a/EdgeAgentSDK/EdgeAgent/Tests/PrismOnboardingInvitationTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/PrismOnboardingInvitationTests.swift
@@ -31,6 +31,19 @@ final class PrismOnboardingInvitationTests: XCTestCase {
         XCTAssertThrowsError(try PrismOnboardingInvitation(jsonString: jsonString))
     }
 
+    func testConnectionlessPresentationParsing() async throws {
+        let connectionLessPresentation = "eyJpZCI6IjViMjUwMjIzLWExNDItNDRmYi1hOWJkLWU1MjBlNGI0ZjQzMiIsInR5cGUiOiJodHRwczovL2RpZGNvbW0ub3JnL291dC1vZi1iYW5kLzIuMC9pbnZpdGF0aW9uIiwiZnJvbSI6ImRpZDpwZWVyOjIuRXo2TFNkV0hWQ1BFOHc0NWZETjM4aUh0ZFJ6WGkyTFNqQmRSUjRGTmNOUm12VkNKcy5WejZNa2Z2aUI5S1F1OGlnNVZpeG1HZHM3dmdMNmoyUXNOUGFybkZaanBNQ0E5aHpQLlNleUowSWpvaVpHMGlMQ0p6SWpwN0luVnlhU0k2SW1oMGRIQTZMeTh4T1RJdU1UWTRMakV1TXpjNk9EQTNNQzlrYVdSamIyMXRJaXdpY2lJNlcxMHNJbUVpT2xzaVpHbGtZMjl0YlM5Mk1pSmRmWDAiLCJib2R5Ijp7ImdvYWxfY29kZSI6InByZXNlbnQtdnAiLCJnb2FsIjoiUmVxdWVzdCBwcm9vZiBvZiB2YWNjaW5hdGlvbiBpbmZvcm1hdGlvbiIsImFjY2VwdCI6W119LCJhdHRhY2htZW50cyI6W3siaWQiOiIyYTZmOGM4NS05ZGE3LTRkMjQtOGRhNS0wYzliZDY5ZTBiMDEiLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6eyJpZCI6IjI1NTI5MTBiLWI0NmMtNDM3Yy1hNDdhLTlmODQ5OWI5ZTg0ZiIsInR5cGUiOiJodHRwczovL2RpZGNvbW0uYXRhbGFwcmlzbS5pby9wcmVzZW50LXByb29mLzMuMC9yZXF1ZXN0LXByZXNlbnRhdGlvbiIsImJvZHkiOnsiZ29hbF9jb2RlIjoiUmVxdWVzdCBQcm9vZiBQcmVzZW50YXRpb24iLCJ3aWxsX2NvbmZpcm0iOmZhbHNlLCJwcm9vZl90eXBlcyI6W119LCJhdHRhY2htZW50cyI6W3siaWQiOiJiYWJiNTJmMS05NDUyLTQzOGYtYjk3MC0yZDJjOTFmZTAyNGYiLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6eyJvcHRpb25zIjp7ImNoYWxsZW5nZSI6IjExYzkxNDkzLTAxYjMtNGM0ZC1hYzM2LWIzMzZiYWI1YmRkZiIsImRvbWFpbiI6Imh0dHBzOi8vcHJpc20tdmVyaWZpZXIuY29tIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiMGNmMzQ2ZDItYWY1Ny00Y2E1LTg2Y2EtYTA1NTE1NjZlYzZmIiwiaW5wdXRfZGVzY3JpcHRvcnMiOltdfX19LCJmb3JtYXQiOiJwcmlzbS9qd3QifV0sInRoaWQiOiI1YjI1MDIyMy1hMTQyLTQ0ZmItYTliZC1lNTIwZTRiNGY0MzIiLCJmcm9tIjoiZGlkOnBlZXI6Mi5FejZMU2RXSFZDUEU4dzQ1ZkROMzhpSHRkUnpYaTJMU2pCZFJSNEZOY05SbXZWQ0pzLlZ6Nk1rZnZpQjlLUXU4aWc1Vml4bUdkczd2Z0w2ajJRc05QYXJuRlpqcE1DQTloelAuU2V5SjBJam9pWkcwaUxDSnpJanA3SW5WeWFTSTZJbWgwZEhBNkx5OHhPVEl1TVRZNExqRXVNemM2T0RBM01DOWthV1JqYjIxdElpd2ljaUk2VzEwc0ltRWlPbHNpWkdsa1kyOXRiUzkyTWlKZGZYMCJ9fX1dLCJjcmVhdGVkX3RpbWUiOjE3MjQzMzkxNDQsImV4cGlyZXNfdGltZSI6MTcyNDMzOTQ0NH0="
+
+        let agent = EdgeAgent(mediatorDID: .init(method: "peer", methodId: "test"))
+        let result = try await agent.parseInvitation(str: connectionLessPresentation)
+        switch result {
+        case .connectionlessPresentation(let requestPresentation):
+            break
+        default:
+            XCTFail("It should give a connectionless presentation request")
+        }
+    }
+
 //    func testLocal() async throws {
 //        let example = PrismOnboardingInvitation.Body(
 //            type: "https://atalaprism.io/did-request",

--- a/EdgeAgentSDK/Mercury/Sources/Forward/ForwardMessage.swift
+++ b/EdgeAgentSDK/Mercury/Sources/Forward/ForwardMessage.swift
@@ -40,7 +40,7 @@ public struct ForwardMessage {
             to: to,
             body: try JSONEncoder.didComm().encode(self.body),
             attachments: [
-                .init(mediaType: "application/json", data: AttachmentJsonData(data: encryptedJsonMessage))
+                .init(mediaType: "application/json", data: AttachmentBase64(base64: encryptedJsonMessage.base64URLEncoded()))
             ]
         )
     }

--- a/EdgeAgentSDK/Mercury/Sources/Helpers/DIDCommMessage+DomainParse.swift
+++ b/EdgeAgentSDK/Mercury/Sources/Helpers/DIDCommMessage+DomainParse.swift
@@ -93,7 +93,7 @@ extension Domain.AttachmentData {
             return try JsonAttachmentData(
                 hash: nil,
                 jws: nil,
-                json: jsonData.data.tryToString()
+                json: JSONEncoder.didComm().encode(jsonData.json).tryToString()
             )
         } else if let jwsData = self as? AttachmentJwsData {
             return Base64AttachmentData(
@@ -118,10 +118,8 @@ extension DIDCommSwift.AttachmentData {
             }
             return AttachmentLinkData(links: value.links, hash: hash)
         case let value as JsonAttachmentData:
-            guard let jsonData = value.json.data(using: .utf8) else {
-                throw MercuryError.unknownAttachmentDataTypeError
-            }
-            return AttachmentJsonData(data: jsonData)
+            let jsonObject = try JSONDecoder.didComm().decode(Domain.AnyCodable.self, from: value.json.tryToData())
+            return AttachmentJsonData(json: jsonObject)
         default:
             throw MercuryError.unknownAttachmentDataTypeError
         }

--- a/EdgeAgentSDK/Pollux/Sources/Models/AnonCreds/AnoncredsCredentialStack+ProvableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/AnonCreds/AnoncredsCredentialStack+ProvableCredential.swift
@@ -12,7 +12,7 @@ extension AnoncredsCredentialStack: ProvableCredential {
         }
         switch attachment.data {
         case let attachmentData as AttachmentJsonData:
-            requestStr = try attachmentData.data.toString()
+            requestStr = try JSONEncoder.didComm().encode(attachmentData.json).tryToString()
         case let attachmentData as AttachmentBase64:
             guard let data = Data(fromBase64URL: attachmentData.base64) else {
                 throw PolluxError.messageDoesntProvideEnoughInformation

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTCredential+ProofableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTCredential+ProofableCredential.swift
@@ -23,7 +23,7 @@ extension JWTCredential: ProvableCredential {
         case let attchedData as AttachmentBase64:
             jsonData = Data(fromBase64URL: attchedData.base64)!
         case let attchedData as AttachmentJsonData:
-            jsonData = attchedData.data
+            jsonData = try JSONEncoder.didComm().encode(attchedData.json)
         default:
             throw PolluxError.invalidAttachmentType(supportedTypes: ["Json", "Base64"])
         }

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload+Codable.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload+Codable.swift
@@ -1,4 +1,3 @@
-import Core
 import Domain
 import Foundation
 

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload.swift
@@ -18,7 +18,7 @@ struct JWTPayload {
         let context: Set<String>
         let type: Set<String>
         let credentialSchema: VerifiableCredentialTypeContainer?
-        let credentialSubject: AnyCodable
+        let credentialSubject: Domain.AnyCodable
         let refreshService: VerifiableCredentialTypeContainer?
         let evidence: VerifiableCredentialTypeContainer?
         let termsOfUse: VerifiableCredentialTypeContainer?
@@ -41,7 +41,7 @@ struct JWTPayload {
             context: Set<String> = Set(),
             type: Set<String> = Set(),
             credentialSchema: VerifiableCredentialTypeContainer? = nil,
-            credentialSubject: AnyCodable,
+            credentialSubject: Domain.AnyCodable,
             credentialStatus: JWTRevocationStatus? = nil,
             refreshService: VerifiableCredentialTypeContainer? = nil,
             evidence: VerifiableCredentialTypeContainer? = nil,

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPresentation.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPresentation.swift
@@ -66,7 +66,7 @@ struct JWTPresentation {
             let requestData = request.attachments.first.flatMap({
                 switch $0.data {
                 case let json as AttachmentJsonData:
-                    return json.data
+                    return try? JSONEncoder.didComm().encode(json.json)
                 case let bas64 as AttachmentBase64:
                     return Data(fromBase64URL: bas64.base64)
                 default:

--- a/EdgeAgentSDK/Pollux/Sources/Models/SDJWT/SDJWTPresentation.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/SDJWT/SDJWTPresentation.swift
@@ -39,7 +39,7 @@ struct SDJWTPresentation {
             let requestData = request.attachments.first.flatMap({
                 switch $0.data {
                 case let json as AttachmentJsonData:
-                    return json.data
+                    return try? JSONEncoder.didComm().encode(json.json)
                 case let bas64 as AttachmentBase64:
                     return Data(fromBase64URL: bas64.base64)
                 default:

--- a/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential+Codable.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential+Codable.swift
@@ -1,4 +1,3 @@
-import Core
 import Domain
 import Foundation
 

--- a/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential.swift
@@ -11,7 +11,7 @@ struct W3CVerifiableCredential {
     let issuanceDate: Date
     let expirationDate: Date?
     let credentialSchema: VerifiableCredentialTypeContainer?
-    let credentialSubject: AnyCodable
+    let credentialSubject: Domain.AnyCodable
     let credentialStatus: VerifiableCredentialTypeContainer?
     let refreshService: VerifiableCredentialTypeContainer?
     let evidence: VerifiableCredentialTypeContainer?
@@ -30,7 +30,7 @@ struct W3CVerifiableCredential {
         issuanceDate: Date,
         expirationDate: Date? = nil,
         credentialSchema: VerifiableCredentialTypeContainer? = nil,
-        credentialSubject: AnyCodable,
+        credentialSubject: Domain.AnyCodable,
         credentialStatus: VerifiableCredentialTypeContainer? = nil,
         refreshService: VerifiableCredentialTypeContainer? = nil,
         evidence: VerifiableCredentialTypeContainer? = nil,

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialRequest.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialRequest.swift
@@ -21,14 +21,20 @@ extension PolluxImpl {
         case "jwt", "prism/jwt", .none:
             switch offerAttachment.data {
             case let json as AttachmentJsonData:
-                return try await processJWTCredentialRequest(offerData: json.data, options: options)
+                return try await processJWTCredentialRequest(
+                    offerData: try JSONEncoder.didComm().encode(json.json),
+                    options: options
+                )
             default:
                 throw PolluxError.offerDoesntProvideEnoughInformation
             }
         case "vc+sd-jwt":
             switch offerAttachment.data {
             case let json as AttachmentJsonData:
-                return try await processSDJWTCredentialRequest(offerData: json.data, options: options)
+                return try await processSDJWTCredentialRequest(
+                    offerData: try JSONEncoder.didComm().encode(json.json),
+                    options: options
+                )
             default:
                 throw PolluxError.offerDoesntProvideEnoughInformation
             }
@@ -39,7 +45,7 @@ extension PolluxImpl {
                     throw PolluxError.messageDoesntProvideEnoughInformation
                 }
                 return try await processAnoncredsCredentialRequest(
-                    offerData: attachmentData.data,
+                    offerData: try JSONEncoder.didComm().encode(attachmentData.json),
                     thid: thid,
                     options: options
                 )

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialVerification.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialVerification.swift
@@ -32,7 +32,7 @@ extension PolluxImpl {
             }
             jsonData = decoded
         case let attchedData as AttachmentJsonData:
-            jsonData = attchedData.data
+            jsonData = try JSONEncoder.didComm().encode(attchedData.json)
         default:
             throw PolluxError.invalidAttachmentType(supportedTypes: ["Json", "Base64"])
         }
@@ -70,7 +70,7 @@ extension PolluxImpl {
         let json: Data
         switch attachmentData {
         case let jsonData as AttachmentJsonData:
-            json = jsonData.data
+            json = try JSONEncoder.didComm().encode(jsonData.json)
         case let base64Data as AttachmentBase64:
             json = try base64Data.decoded()
         default:
@@ -175,7 +175,7 @@ extension PolluxImpl {
         let json: Data
         switch attachmentData {
         case let jsonData as AttachmentJsonData:
-            json = jsonData.data
+            json = try JSONEncoder.didComm().encode(jsonData.json)
         case let base64Data as AttachmentBase64:
             guard let data = try Data(fromBase64URL: base64Data.base64.tryToData()) else {
                 throw CommonError.invalidCoding(message: "Could not decode base64 message attchment")
@@ -258,5 +258,5 @@ private struct AnonPresentation: Codable {
 }
 
 private struct ValidateJsonSchemaContainer: Codable {
-    let value: AnyCodable
+    let value: Domain.AnyCodable
 }

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+ParseCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+ParseCredential.swift
@@ -11,7 +11,9 @@ extension PolluxImpl {
         case "jwt", "", "prism/jwt", .none:
             switch issuedAttachment.data {
             case let json as AttachmentJsonData:
-                return try ParseJWTCredentialFromMessage.parse(issuerCredentialData: json.data)
+                return try ParseJWTCredentialFromMessage.parse(
+                    issuerCredentialData: try JSONEncoder.didComm().encode(json.json)
+                )
             case let base64 as AttachmentBase64:
                 return try ParseJWTCredentialFromMessage.parse(issuerCredentialData: try base64.decoded())
             default:
@@ -20,7 +22,9 @@ extension PolluxImpl {
         case "vc+sd-jwt":
             switch issuedAttachment.data {
             case let json as AttachmentJsonData:
-                return try SDJWTCredential(sdjwtString: json.data.tryToString())
+                return try SDJWTCredential(
+                    sdjwtString: try JSONEncoder.didComm().encode(json.json).toString()
+                )
             case let base64 as AttachmentBase64:
                 return try SDJWTCredential(sdjwtString: try base64.decoded().tryToString())
             default:
@@ -63,7 +67,7 @@ extension PolluxImpl {
             switch issuedAttachment.data {
             case let json as AttachmentJsonData:
                 return try await ParseAnoncredsCredentialFromMessage.parse(
-                    issuerCredentialData: json.data,
+                    issuerCredentialData: try JSONEncoder.didComm().encode(json.json),
                     linkSecret: linkSecret,
                     credentialDefinitionDownloader: definitionDownloader,
                     schemaDownloader: schemaDownloader,


### PR DESCRIPTION
### Description: 
Now the agent can process a connectionless presentation request

BREAKING CHANGE: AttachmentJsonData was wrong and is now a AnyCodable instead of a Data

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
