### PR TITLE
test: fixes revoked jwt verification test

### DIFF
--- a/E2E/e2eTests/Source/Workflows/EdgeAgentWorkflow.swift
+++ b/E2E/e2eTests/Source/Workflows/EdgeAgentWorkflow.swift
@@ -342,17 +342,16 @@ class EdgeAgentWorkflow {
         let presentation = try await edgeAgent.using(ability: UseWalletSdk.self, action: "retrieves presentation message")
             .presentationStack.removeFirst()
         do {
-            let result = try await edgeAgent.using(ability: UseWalletSdk.self, action: "")
+            let result = try await edgeAgent.using(ability: UseWalletSdk.self, action: "verify the presentation")
                 .sdk.verifyPresentation(message: presentation)
             assertThat(result, equalTo(expected))
-        } catch PolluxError.cannotVerifyPresentationInputs {
-            
-            print("teste")
-            //              if (e.message.includes("credential is revoked")) {
-            //                assert.isTrue(expected === false)
-            //              } else {
-            //                throw e
-            //              }
+        } catch let error as PolluxError {
+            switch error {
+            case .credentialIsRevoked:
+                assertThat(expected == false)
+            default:
+                throw error
+            }
         }
     }
 }


### PR DESCRIPTION
### Description: 
Fixes the e2e test for revoked jwt verification

### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
