### PR TITLE
feat(edgeagent): adds support for connectionless issuance and presentation

### DIFF
--- a/EdgeAgentSDK/Castor/Sources/Resolvers/LongFormPrismDIDResolver.swift
+++ b/EdgeAgentSDK/Castor/Sources/Resolvers/LongFormPrismDIDResolver.swift
@@ -113,22 +113,22 @@ struct LongFormPrismDIDResolver: DIDResolverDomain {
             )
         }
 
-        let decodedPublicKeys = publicKeys.map {
+        let decodedPublicKeys = publicKeys.enumerated().map {
             let didUrl = DIDUrl(
                 did: did,
-                fragment: $0.id
+                fragment: $0.element.usage.id(index: $0.offset - 1)
             )
 
             let method = DIDDocument.VerificationMethod(
                 id: didUrl,
                 controller: did,
-                type: $0.keyData.getProperty(.curve) ?? "",
-                publicKeyMultibase: $0.keyData.raw.base64EncodedString()
+                type: $0.element.keyData.getProperty(.curve) ?? "",
+                publicKeyMultibase: $0.element.keyData.raw.base64EncodedString()
             )
 
             return PublicKeyDecoded(
                 id: didUrl.string,
-                keyType: .init(usage: $0.usage),
+                keyType: .init(usage: $0.element.usage),
                 method: method
             )
         }

--- a/EdgeAgentSDK/Castor/Sources/Resolvers/PeerDIDResolver.swift
+++ b/EdgeAgentSDK/Castor/Sources/Resolvers/PeerDIDResolver.swift
@@ -203,7 +203,7 @@ extension DIDCore.DIDDocument.VerificationMethod {
 }
 
 extension DIDCore.DIDDocument.Service {
-    init(from: AnyCodable) throws {
+    init(from: DIDCore.AnyCodable) throws {
         guard
             let dic = from.value as? [String: Any],
             let id = dic["id"] as? String,
@@ -211,7 +211,7 @@ extension DIDCore.DIDDocument.Service {
             let serviceEndpoint = dic["serviceEndpoint"]
         else { throw CommonError.invalidCoding(message: "Could not decode service") }
         switch serviceEndpoint {
-        case let value as AnyCodable:
+        case let value as DIDCore.AnyCodable:
             self = .init(
                 id: id,
                 type: type,
@@ -221,26 +221,26 @@ extension DIDCore.DIDDocument.Service {
             self = .init(
                 id: id,
                 type: type,
-                serviceEndpoint: AnyCodable(value)
+                serviceEndpoint: DIDCore.AnyCodable(value)
             )
         case let value as [String: Any]:
             self = .init(
                 id: id,
                 type: type,
-                serviceEndpoint: AnyCodable(value)
+                serviceEndpoint: DIDCore.AnyCodable(value)
             )
         case let value as [String]:
             self = .init(
                 id: id,
                 type: type,
-                serviceEndpoint: AnyCodable(value)
+                serviceEndpoint: DIDCore.AnyCodable(value)
             )
         default:
             throw CommonError.invalidCoding(message: "Could not decode service")
         }
     }
 
-    func toAnyCodable() -> AnyCodable {
+    func toAnyCodable() -> DIDCore.AnyCodable {
         AnyCodable(dictionaryLiteral:
             ("id", self.id),
             ("type", self.type),

--- a/EdgeAgentSDK/Castor/Tests/DIDParserTests.swift
+++ b/EdgeAgentSDK/Castor/Tests/DIDParserTests.swift
@@ -1,3 +1,5 @@
+import Apollo
+@testable import Castor
 @testable import Domain
 import XCTest
 

--- a/EdgeAgentSDK/Domain/Sources/AnyCodable.swift
+++ b/EdgeAgentSDK/Domain/Sources/AnyCodable.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-struct AnyCodable {
-    let value: Any
+public struct AnyCodable {
+    public let value: Any
 
-    init<T: Codable>(_ value: T) {
+    public init<T: Codable>(_ value: T) {
         self.value = value
     }
 
@@ -11,17 +11,17 @@ struct AnyCodable {
         self.value = value
     }
 
-    func get<T>() -> T? {
+    public func get<T>() -> T? {
         value as? T
     }
 
-    func get() -> Any {
+    public func get() -> Any {
         value
     }
 }
 
 extension AnyCodable: Codable {
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -48,7 +48,7 @@ extension AnyCodable: Codable {
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch self.value {
@@ -103,7 +103,7 @@ extension AnyCodable: Codable {
 }
 
 extension AnyCodable: Equatable {
-    static func ==(lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+    public static func ==(lhs: AnyCodable, rhs: AnyCodable) -> Bool {
         switch (lhs.value, rhs.value) {
         case is (Void, Void):
             return true
@@ -146,7 +146,7 @@ extension AnyCodable: Equatable {
 }
 
 extension AnyCodable: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch value {
         case is Void:
             return String(describing: nil as Any?)
@@ -159,7 +159,7 @@ extension AnyCodable: CustomStringConvertible {
 }
 
 extension AnyCodable: CustomDebugStringConvertible {
-    var debugDescription: String {
+    public var debugDescription: String {
         switch value {
         case let value as CustomDebugStringConvertible:
             return "AnyCodable(\(value.debugDescription))"
@@ -171,35 +171,35 @@ extension AnyCodable: CustomDebugStringConvertible {
 
 extension AnyCodable: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral, ExpressibleByStringLiteral, ExpressibleByArrayLiteral, ExpressibleByDictionaryLiteral {
 
-    init(nilLiteral: ()) {
+    public init(nilLiteral: ()) {
         self.init(nil ?? ())
     }
 
-    init(booleanLiteral value: Bool) {
+    public init(booleanLiteral value: Bool) {
         self.init(value)
     }
 
-    init(integerLiteral value: Int) {
+    public init(integerLiteral value: Int) {
         self.init(value)
     }
 
-    init(floatLiteral value: Double) {
+    public init(floatLiteral value: Double) {
         self.init(value)
     }
 
-    init(extendedGraphemeClusterLiteral value: String) {
+    public init(extendedGraphemeClusterLiteral value: String) {
         self.init(value)
     }
 
-    init(stringLiteral value: String) {
+    public init(stringLiteral value: String) {
         self.init(value)
     }
 
-    init(arrayLiteral elements: Any...) {
+    public init(arrayLiteral elements: Any...) {
         self.init(elements)
     }
 
-    init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+    public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
         self.init(Dictionary<AnyHashable, Any>(elements, uniquingKeysWith: { (first, _) in first }))
     }
 }

--- a/EdgeAgentSDK/Domain/Sources/Models/Message+Codable.swift
+++ b/EdgeAgentSDK/Domain/Sources/Models/Message+Codable.swift
@@ -4,6 +4,7 @@ extension Message: Codable {
     enum CodingKeys: String, CodingKey {
         case id
         case piuri
+        case type
         case from
         case to
         case fromPrior
@@ -21,7 +22,7 @@ extension Message: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
-        try container.encode(piuri, forKey: .piuri)
+        try container.encode(piuri, forKey: .type)
         if let dic = try? JSONSerialization.jsonObject(with: body) as? [String: Any?] {
             var filteredDictionary = dic
             for (key, value) in dic {
@@ -49,7 +50,12 @@ extension Message: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let id = try container.decode(String.self, forKey: .id)
-        let piuri = try container.decode(String.self, forKey: .piuri)
+        let piuri: String
+        if let type = try container.decodeIfPresent(String.self, forKey: .piuri) {
+            piuri = type
+        } else {
+            piuri = try container.decode(String.self, forKey: .type)
+        }
         let body: Data?
         if 
             let bodyCodable = try? container.decodeIfPresent(AnyCodable.self, forKey: .body),

--- a/EdgeAgentSDK/Domain/Sources/Models/MessageAttachment.swift
+++ b/EdgeAgentSDK/Domain/Sources/Models/MessageAttachment.swift
@@ -96,12 +96,12 @@ public struct AttachmentLinkData: AttachmentData {
 /// The `AttachmentJsonData` struct represents a DIDComm attachment containing JSON data.
 public struct AttachmentJsonData: AttachmentData {
     /// The JSON data associated with the attachment.
-    public let data: Data
+    public let json: AnyCodable
 
     /// Initializes a new `AttachmentJsonData` object with the specified properties.
     /// - Parameter data: The JSON data associated with the attachment.
-    public init(data: Data) {
-        self.data = data
+    public init(json: AnyCodable) {
+        self.json = json
     }
 }
 

--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
@@ -86,7 +86,7 @@ public extension DIDCommAgent {
                 }
                 jsonData = decoded
             case let attchedData as AttachmentJsonData:
-                jsonData = attchedData.data
+                jsonData = try JSONEncoder.didComm().encode(attchedData.json)
             default:
                 throw EdgeAgentError.invalidAttachmentFormat(nil)
             }
@@ -141,7 +141,7 @@ public extension DIDCommAgent {
             }
             jsonData = decoded
         case let attchedData as AttachmentJsonData:
-            jsonData = attchedData.data
+            jsonData = try JSONEncoder.didComm().encode(attchedData.json)
         default:
             throw EdgeAgentError.invalidAttachmentFormat(nil)
         }
@@ -210,7 +210,7 @@ public extension DIDCommAgent {
             }
             jsonData = decoded
         case let attchedData as AttachmentJsonData:
-            jsonData = attchedData.data
+            jsonData = try JSONEncoder.didComm().encode(attchedData.json)
         default:
             throw EdgeAgentError.invalidAttachmentFormat(nil)
         }

--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Invitations.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Invitations.swift
@@ -18,6 +18,10 @@ public extension DIDCommAgent {
         case onboardingPrism(PrismOnboarding)
         /// Case representing a DIDComm Out-of-Band invitation
         case onboardingDIDComm(OutOfBandInvitation)
+        /// Case representing a DIDComm Connectionless Presentation
+        case connectionlessPresentation(RequestPresentation)
+        /// Case representing a DIDComm Connectionless Issuance
+        case connectionlessIssuance(OfferCredential3_0)
     }
 
     /// Parses the given string as an Out-of-Band invitation
@@ -25,8 +29,17 @@ public extension DIDCommAgent {
     /// - Returns: The parsed Out-of-Band invitation
     /// - Throws: `EdgeAgentError` if the string is not a valid URL
     func parseOOBInvitation(url: String) throws -> OutOfBandInvitation {
-        guard let url = URL(string: url) else { throw CommonError.invalidURLError(url: url) }
-        return try parseOOBInvitation(url: url)
+        guard let messageData = Data(fromBase64URL: url) else {
+            guard let url = URL(string: url) else {
+                throw CommonError.invalidURLError(url: url)
+            }
+            return try parseOOBInvitation(url: url)
+        }
+        let message = try JSONDecoder.didComm().decode(OutOfBandInvitation.self, from: messageData)
+        guard message.type == ProtocolTypes.didcomminvitation.rawValue else {
+            throw EdgeAgentError.unknownInvitationTypeError
+        }
+        return message
     }
 
     /// Parses the given URL as an Out-of-Band invitation
@@ -71,8 +84,26 @@ public extension DIDCommAgent {
     func parseInvitation(str: String) async throws -> InvitationType {
         if let prismOnboarding = try? await parsePrismInvitation(str: str) {
             return .onboardingPrism(prismOnboarding)
-        } else if let message = try? parseOOBInvitation(url: str) {
-            return .onboardingDIDComm(message)
+        } else if let oobMessage = try? parseOOBInvitation(url: str) {
+            if let attachment = oobMessage.attachments?.first {
+                let invitationType = try await parseAttachmentConnectionlessMessage(oob: oobMessage, attachment: attachment)
+                switch invitationType {
+                case .connectionlessPresentation(let message):
+                    try await pluto.storeMessage(
+                        message: message.makeMessage(),
+                        direction: .received
+                    ).first().await()
+                case .connectionlessIssuance(let message):
+                    try await pluto.storeMessage(
+                        message: message.makeMessage(),
+                        direction: .received
+                    ).first().await()
+                default:
+                    break
+                }
+                return invitationType
+            }
+            return .onboardingDIDComm(oobMessage)
         }
         throw EdgeAgentError.unknownInvitationTypeError
     }
@@ -126,5 +157,36 @@ public extension DIDCommAgent {
             connection: connectionManager
         ).run()
         try await connectionManager.addConnection(pair)
+    }
+
+    private func parseAttachmentConnectionlessMessage(
+        oob: OutOfBandInvitation,
+        attachment: AttachmentDescriptor
+    ) async throws -> InvitationType {
+        let newDID = try await createNewPeerDID(updateMediator: true)
+        switch attachment.data {
+        case let value as AttachmentJsonData:
+            let normalizeJson = try JSONEncoder.didComm().encode(value.json)
+            let message = try JSONDecoder.didComm().decode(Message.self, from: normalizeJson)
+            if let request = try? RequestPresentation(fromMessage: message, toDID: newDID) {
+                return .connectionlessPresentation(request)
+            }
+            else if let offer = try? OfferCredential3_0(fromMessage: message, toDID: newDID){
+                return .connectionlessIssuance(offer)
+            }
+            return .onboardingDIDComm(oob)
+
+        case let value as AttachmentBase64:
+            let message = try JSONDecoder.didComm().decode(Message.self, from: try value.decoded())
+            if let request = try? RequestPresentation(fromMessage: message, toDID: newDID) {
+                return .connectionlessPresentation(request)
+            }
+            else if let offer = try? OfferCredential3_0(fromMessage: message, toDID: newDID){
+                return .connectionlessIssuance(offer)
+            }
+            return .onboardingDIDComm(oob)
+        default:
+            return .onboardingDIDComm(oob)
+        }
     }
 }

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Invitation/V2/OutOfBandInvitation.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Invitation/V2/OutOfBandInvitation.swift
@@ -27,6 +27,7 @@ public struct OutOfBandInvitation: Decodable {
     public let type = ProtocolTypes.didcomminvitation.rawValue
     public let from: String
     public let body: Body
+    public let attachments: [AttachmentDescriptor]?
 
     /**
      Creates a new `OutOfBandInvitation` object.
@@ -42,11 +43,13 @@ public struct OutOfBandInvitation: Decodable {
     init(
         id: String = UUID().uuidString,
         body: Body,
-        from: DID
+        from: DID,
+        attachments: [AttachmentDescriptor]? = nil
     ) {
         self.id = id
         self.body = body
         self.from = from.string
+        self.attachments = attachments
     }
 }
 

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/OfferCredential.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/OfferCredential.swift
@@ -182,12 +182,12 @@ public struct OfferCredential3_0 {
         self.to = to
     }
 
-    public init(fromMessage: Message) throws {
+    public init(fromMessage: Message, toDID: DID? = nil) throws {
         guard
             let piuri = ProtocolTypes(rawValue: fromMessage.piuri),
              piuri == ProtocolTypes.didcommOfferCredential3_0,
             let fromDID = fromMessage.from,
-            let toDID = fromMessage.to
+            let toDID = fromMessage.to ?? toDID
         else { throw EdgeAgentError.invalidMessageType(
             type: fromMessage.piuri,
             shouldBe: [ProtocolTypes.didcommOfferCredential.rawValue]

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Pickup/PickupRunner.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/Pickup/PickupRunner.swift
@@ -37,7 +37,7 @@ class PickupRunner {
                     else { return nil }
                     return (base64String, attachment.id)
                 case let json as AttachmentJsonData:
-                    return String(data: json.data, encoding: .utf8).map { ($0, attachment.id) }
+                    return (try JSONEncoder.didComm().encode(json.json).tryToString(), attachment.id)
                 default:
                     return nil
                 }

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/ProofPresentation/RequestPresentation.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/ProofPresentation/RequestPresentation.swift
@@ -45,11 +45,11 @@ public struct RequestPresentation {
         self.to = to
     }
 
-    public init(fromMessage: Message) throws {
+    public init(fromMessage: Message, toDID: DID? = nil) throws {
         guard
             fromMessage.piuri == ProtocolTypes.didcommRequestPresentation.rawValue,
             let fromDID = fromMessage.from,
-            let toDID = fromMessage.to
+            let toDID = fromMessage.to ?? toDID
         else { throw EdgeAgentError.invalidMessageType(
             type: fromMessage.piuri,
             shouldBe: [ProtocolTypes.didcommRequestPresentation.rawValue]

--- a/EdgeAgentSDK/EdgeAgent/Tests/Helper/MockMediatorHandler.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/Helper/MockMediatorHandler.swift
@@ -1,0 +1,42 @@
+import Domain
+@testable import EdgeAgent
+
+let mockMediator = Mediator(
+    hostDID: DID(method: "test", methodId: "test"),
+    routingDID: DID(method: "test", methodId: "test"),
+    mediatorDID: DID(method: "test", methodId: "test")
+)
+
+class MockMediatorHandler: MediatorHandler {
+    let mediatorDID: DID
+    let mediator: Mediator?
+    var messages: [Message]
+
+    init(
+        mediatorDID: DID = .init(method: "test", methodId: "test"),
+        mediator: Mediator? = mockMediator,
+        messages: [Message] = []
+    ) {
+        self.mediatorDID = mediatorDID
+        self.mediator = mediator
+        self.messages = messages
+    }
+
+    func bootRegisteredMediator() async throws -> Mediator? {
+        mediator
+    }
+    
+    func achieveMediation(host: DID) async throws -> Mediator {
+        mediator!
+    }
+    
+    func updateKeyListWithDIDs(dids: [Domain.DID]) async throws {}
+    
+    func pickupUnreadMessages(limit: Int) async throws -> [(String, Domain.Message)] {
+        messages.map { ($0.id, $0) }
+    }
+    
+    func registerMessagesAsRead(ids: [String]) async throws {
+        messages.removeAll { ids.contains($0.id) }
+    }
+}

--- a/EdgeAgentSDK/EdgeAgent/Tests/Helper/MockMercury.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/Helper/MockMercury.swift
@@ -1,0 +1,20 @@
+import Domain
+import Foundation
+
+struct MockMercury: Mercury {
+    func packMessage(msg: Domain.Message) async throws -> String {
+        ""
+    }
+    
+    func unpackMessage(msg: String) async throws -> Domain.Message {
+        Message(piuri: "test", body: Data())
+    }
+    
+    func sendMessage(_ msg: Domain.Message) async throws -> Data? {
+        nil
+    }
+    
+    func sendMessageParseMessage(msg: Domain.Message) async throws -> Domain.Message? {
+        nil
+    }
+}

--- a/EdgeAgentSDK/EdgeAgent/Tests/PrismOnboardingInvitationTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/PrismOnboardingInvitationTests.swift
@@ -31,6 +31,52 @@ final class PrismOnboardingInvitationTests: XCTestCase {
         XCTAssertThrowsError(try PrismOnboardingInvitation(jsonString: jsonString))
     }
 
+    func testConnectionlessPresentationParsing() async throws {
+        let connectionLessPresentation = "eyJpZCI6IjViMjUwMjIzLWExNDItNDRmYi1hOWJkLWU1MjBlNGI0ZjQzMiIsInR5cGUiOiJodHRwczovL2RpZGNvbW0ub3JnL291dC1vZi1iYW5kLzIuMC9pbnZpdGF0aW9uIiwiZnJvbSI6ImRpZDpwZWVyOjIuRXo2TFNkV0hWQ1BFOHc0NWZETjM4aUh0ZFJ6WGkyTFNqQmRSUjRGTmNOUm12VkNKcy5WejZNa2Z2aUI5S1F1OGlnNVZpeG1HZHM3dmdMNmoyUXNOUGFybkZaanBNQ0E5aHpQLlNleUowSWpvaVpHMGlMQ0p6SWpwN0luVnlhU0k2SW1oMGRIQTZMeTh4T1RJdU1UWTRMakV1TXpjNk9EQTNNQzlrYVdSamIyMXRJaXdpY2lJNlcxMHNJbUVpT2xzaVpHbGtZMjl0YlM5Mk1pSmRmWDAiLCJib2R5Ijp7ImdvYWxfY29kZSI6InByZXNlbnQtdnAiLCJnb2FsIjoiUmVxdWVzdCBwcm9vZiBvZiB2YWNjaW5hdGlvbiBpbmZvcm1hdGlvbiIsImFjY2VwdCI6W119LCJhdHRhY2htZW50cyI6W3siaWQiOiIyYTZmOGM4NS05ZGE3LTRkMjQtOGRhNS0wYzliZDY5ZTBiMDEiLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6eyJpZCI6IjI1NTI5MTBiLWI0NmMtNDM3Yy1hNDdhLTlmODQ5OWI5ZTg0ZiIsInR5cGUiOiJodHRwczovL2RpZGNvbW0uYXRhbGFwcmlzbS5pby9wcmVzZW50LXByb29mLzMuMC9yZXF1ZXN0LXByZXNlbnRhdGlvbiIsImJvZHkiOnsiZ29hbF9jb2RlIjoiUmVxdWVzdCBQcm9vZiBQcmVzZW50YXRpb24iLCJ3aWxsX2NvbmZpcm0iOmZhbHNlLCJwcm9vZl90eXBlcyI6W119LCJhdHRhY2htZW50cyI6W3siaWQiOiJiYWJiNTJmMS05NDUyLTQzOGYtYjk3MC0yZDJjOTFmZTAyNGYiLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6eyJvcHRpb25zIjp7ImNoYWxsZW5nZSI6IjExYzkxNDkzLTAxYjMtNGM0ZC1hYzM2LWIzMzZiYWI1YmRkZiIsImRvbWFpbiI6Imh0dHBzOi8vcHJpc20tdmVyaWZpZXIuY29tIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiMGNmMzQ2ZDItYWY1Ny00Y2E1LTg2Y2EtYTA1NTE1NjZlYzZmIiwiaW5wdXRfZGVzY3JpcHRvcnMiOltdfX19LCJmb3JtYXQiOiJwcmlzbS9qd3QifV0sInRoaWQiOiI1YjI1MDIyMy1hMTQyLTQ0ZmItYTliZC1lNTIwZTRiNGY0MzIiLCJmcm9tIjoiZGlkOnBlZXI6Mi5FejZMU2RXSFZDUEU4dzQ1ZkROMzhpSHRkUnpYaTJMU2pCZFJSNEZOY05SbXZWQ0pzLlZ6Nk1rZnZpQjlLUXU4aWc1Vml4bUdkczd2Z0w2ajJRc05QYXJuRlpqcE1DQTloelAuU2V5SjBJam9pWkcwaUxDSnpJanA3SW5WeWFTSTZJbWgwZEhBNkx5OHhPVEl1TVRZNExqRXVNemM2T0RBM01DOWthV1JqYjIxdElpd2ljaUk2VzEwc0ltRWlPbHNpWkdsa1kyOXRiUzkyTWlKZGZYMCJ9fX1dLCJjcmVhdGVkX3RpbWUiOjE3MjQzMzkxNDQsImV4cGlyZXNfdGltZSI6MTcyNDMzOTQ0NH0="
+
+        let apollo = ApolloBuilder().build()
+        let edgeAgent = EdgeAgent(
+            apollo: apollo,
+            castor: CastorBuilder(apollo: apollo).build(),
+            pluto: MockPluto(),
+            pollux: MockPollux()
+        )
+        let didcommAgent = DIDCommAgent(
+            edgeAgent: edgeAgent,
+            mercury: MockMercury(),
+            mediationHandler: MockMediatorHandler())
+        let result = try await didcommAgent.parseInvitation(str: connectionLessPresentation)
+        switch result {
+        case .connectionlessPresentation(let requestPresentation):
+            break
+        default:
+            XCTFail("It should give a connectionless presentation request")
+        }
+    }
+
+    func testConnectionlessIssuanceParsing() async throws {
+        let connectionLessPresentation = "eyJpZCI6ImY5NmUzNjk5LTU5MWMtNGFlNy1iNWU2LTZlZmU2ZDI2MjU1YiIsInR5cGUiOiJodHRwczovL2RpZGNvbW0ub3JnL291dC1vZi1iYW5kLzIuMC9pbnZpdGF0aW9uIiwiZnJvbSI6ImRpZDpwZWVyOjIuRXo2TFNmc0tNZTh2U1NXa1lkWkNwbjRZVmlQRVJmZEdBaGRMQUdIZ3gyTEdKd2ZtQS5WejZNa3B3MWtTYWJCTXprQTN2NTl0UUZuaDNGdGtLeTZ4TGhMeGQ5UzZCQW9hQmcyLlNleUowSWpvaVpHMGlMQ0p6SWpwN0luVnlhU0k2SW1oMGRIQTZMeTh4T1RJdU1UWTRMakV1TXpjNk9EQTRNQzlrYVdSamIyMXRJaXdpY2lJNlcxMHNJbUVpT2xzaVpHbGtZMjl0YlM5Mk1pSmRmWDAiLCJib2R5Ijp7ImdvYWxfY29kZSI6Imlzc3VlLXZjIiwiZ29hbCI6IlRvIGlzc3VlIGEgRmFiZXIgQ29sbGVnZSBHcmFkdWF0ZSBjcmVkZW50aWFsIiwiYWNjZXB0IjpbImRpZGNvbW0vdjIiXX0sImF0dGFjaG1lbnRzIjpbeyJpZCI6IjcwY2RjOTBjLTlhOTktNGNkYS04N2ZlLTRmNGIyNTk1MTEyYSIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiZGF0YSI6eyJqc29uIjp7ImlkIjoiNjU1ZTlhMmMtNDhlZC00NTliLWIzZGEtNmIzNjg2NjU1NTY0IiwidHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvaXNzdWUtY3JlZGVudGlhbC8zLjAvb2ZmZXItY3JlZGVudGlhbCIsImJvZHkiOnsiZ29hbF9jb2RlIjoiT2ZmZXIgQ3JlZGVudGlhbCIsImNyZWRlbnRpYWxfcHJldmlldyI6eyJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9pc3N1ZS1jcmVkZW50aWFsLzMuMC9jcmVkZW50aWFsLWNyZWRlbnRpYWwiLCJib2R5Ijp7ImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJmYW1pbHlOYW1lIiwidmFsdWUiOiJXb25kZXJsYW5kIn0seyJuYW1lIjoiZ2l2ZW5OYW1lIiwidmFsdWUiOiJBbGljZSJ9LHsibmFtZSI6ImRyaXZpbmdDbGFzcyIsInZhbHVlIjoiTXc9PSIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi9qc29uIn0seyJuYW1lIjoiZGF0ZU9mSXNzdWFuY2UiLCJ2YWx1ZSI6IjIwMjAtMTEtMTNUMjA6MjA6MzkrMDA6MDAifSx7Im5hbWUiOiJlbWFpbEFkZHJlc3MiLCJ2YWx1ZSI6ImFsaWNlQHdvbmRlcmxhbmQuY29tIn0seyJuYW1lIjoiZHJpdmluZ0xpY2Vuc2VJRCIsInZhbHVlIjoiMTIzNDUifV19fX0sImF0dGFjaG1lbnRzIjpbeyJpZCI6Ijg0MDQ2NzhiLTlhMzYtNDk4OS1hZjFkLTBmNDQ1MzQ3ZTBlMyIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiZGF0YSI6eyJqc29uIjp7Im9wdGlvbnMiOnsiY2hhbGxlbmdlIjoiYWQwZjQzYWQtODUzOC00MWQ0LTljYjgtMjA5NjdiYzY4NWJjIiwiZG9tYWluIjoiZG9tYWluIn0sInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiNzQ4ZWZhNTgtMmJjZS00NDBkLTkyMWYtMjUyMGE4NDQ2NjYzIiwiaW5wdXRfZGVzY3JpcHRvcnMiOltdLCJmb3JtYXQiOnsiand0Ijp7ImFsZyI6WyJFUzI1NksiXSwicHJvb2ZfdHlwZSI6W119fX19fSwiZm9ybWF0IjoicHJpc20vand0In1dLCJ0aGlkIjoiZjk2ZTM2OTktNTkxYy00YWU3LWI1ZTYtNmVmZTZkMjYyNTViIiwiZnJvbSI6ImRpZDpwZWVyOjIuRXo2TFNmc0tNZTh2U1NXa1lkWkNwbjRZVmlQRVJmZEdBaGRMQUdIZ3gyTEdKd2ZtQS5WejZNa3B3MWtTYWJCTXprQTN2NTl0UUZuaDNGdGtLeTZ4TGhMeGQ5UzZCQW9hQmcyLlNleUowSWpvaVpHMGlMQ0p6SWpwN0luVnlhU0k2SW1oMGRIQTZMeTh4T1RJdU1UWTRMakV1TXpjNk9EQTRNQzlrYVdSamIyMXRJaXdpY2lJNlcxMHNJbUVpT2xzaVpHbGtZMjl0YlM5Mk1pSmRmWDAifX19XSwiY3JlYXRlZF90aW1lIjoxNzI0ODUxMTM5LCJleHBpcmVzX3RpbWUiOjE3MjQ4NTE0Mzl9"
+
+        let apollo = ApolloBuilder().build()
+        let edgeAgent = EdgeAgent(
+            apollo: apollo,
+            castor: CastorBuilder(apollo: apollo).build(),
+            pluto: MockPluto(),
+            pollux: MockPollux()
+        )
+        let didcommAgent = DIDCommAgent(
+            edgeAgent: edgeAgent,
+            mercury: MockMercury(),
+            mediationHandler: MockMediatorHandler())
+        let result = try await didcommAgent.parseInvitation(str: connectionLessPresentation)
+        switch result {
+        case .connectionlessIssuance(let offerCredential):
+            break
+        default:
+            XCTFail("It should give a connectionless presentation request")
+        }
+    }
+
 //    func testLocal() async throws {
 //        let example = PrismOnboardingInvitation.Body(
 //            type: "https://atalaprism.io/did-request",

--- a/EdgeAgentSDK/Mercury/Sources/Forward/ForwardMessage.swift
+++ b/EdgeAgentSDK/Mercury/Sources/Forward/ForwardMessage.swift
@@ -40,7 +40,12 @@ public struct ForwardMessage {
             to: to,
             body: try JSONEncoder.didComm().encode(self.body),
             attachments: [
-                .init(mediaType: "application/json", data: AttachmentJsonData(data: encryptedJsonMessage))
+                .init(
+                    mediaType: "application/json",
+                    data: AttachmentJsonData(
+                        json: try JSONDecoder.didComm().decode(AnyCodable.self, from: encryptedJsonMessage)
+                    )
+                )
             ]
         )
     }

--- a/EdgeAgentSDK/Mercury/Sources/Helpers/DIDCommMessage+DomainParse.swift
+++ b/EdgeAgentSDK/Mercury/Sources/Helpers/DIDCommMessage+DomainParse.swift
@@ -93,7 +93,7 @@ extension Domain.AttachmentData {
             return try JsonAttachmentData(
                 hash: nil,
                 jws: nil,
-                json: jsonData.data.tryToString()
+                json: try JSONEncoder.didComm().encode(jsonData.json).tryToString()
             )
         } else if let jwsData = self as? AttachmentJwsData {
             return Base64AttachmentData(
@@ -121,7 +121,7 @@ extension DIDCommSwift.AttachmentData {
             guard let jsonData = value.json.data(using: .utf8) else {
                 throw MercuryError.unknownAttachmentDataTypeError
             }
-            return AttachmentJsonData(data: jsonData)
+            return AttachmentJsonData(json: try JSONDecoder().decode(AnyCodable.self, from: jsonData))
         default:
             throw MercuryError.unknownAttachmentDataTypeError
         }

--- a/EdgeAgentSDK/Pollux/Sources/Models/AnonCreds/AnoncredsCredentialStack+ProvableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/AnonCreds/AnoncredsCredentialStack+ProvableCredential.swift
@@ -12,7 +12,7 @@ extension AnoncredsCredentialStack: ProvableCredential {
         }
         switch attachment.data {
         case let attachmentData as AttachmentJsonData:
-            requestStr = try attachmentData.data.toString()
+            requestStr = try JSONEncoder.didComm().encode(attachmentData.json).toString()
         case let attachmentData as AttachmentBase64:
             guard let data = Data(fromBase64URL: attachmentData.base64) else {
                 throw PolluxError.messageDoesntProvideEnoughInformation

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTCredential+ProofableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTCredential+ProofableCredential.swift
@@ -7,10 +7,10 @@ extension JWTCredential: ProvableCredential {
         guard
             let attachment = request.attachments.first,
             let format = attachment.format,
-            let requestData = request.attachments.first.flatMap({
+            let requestData = try request.attachments.first.flatMap({
                 switch $0.data {
                 case let json as AttachmentJsonData:
-                    return json.data
+                    return try JSONEncoder.didComm().encode(json.json)
                 case let bas64 as AttachmentBase64:
                     return Data(fromBase64URL: bas64.base64)
                 default:
@@ -53,7 +53,7 @@ extension JWTCredential: ProvableCredential {
         case let attchedData as AttachmentBase64:
             jsonData = Data(fromBase64URL: attchedData.base64)!
         case let attchedData as AttachmentJsonData:
-            jsonData = attchedData.data
+            jsonData = try JSONEncoder.didComm().encode(attchedData.json)
         default:
             throw PolluxError.invalidAttachmentType(supportedTypes: ["Json", "Base64"])
         }

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload+Codable.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload+Codable.swift
@@ -1,4 +1,3 @@
-import Core
 import Domain
 import Foundation
 

--- a/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/JWT/JWTPayload.swift
@@ -18,7 +18,7 @@ struct JWTPayload {
         let context: Set<String>
         let type: Set<String>
         let credentialSchema: VerifiableCredentialTypeContainer?
-        let credentialSubject: AnyCodable
+        let credentialSubject: Domain.AnyCodable
         let refreshService: VerifiableCredentialTypeContainer?
         let evidence: VerifiableCredentialTypeContainer?
         let termsOfUse: VerifiableCredentialTypeContainer?
@@ -41,7 +41,7 @@ struct JWTPayload {
             context: Set<String> = Set(),
             type: Set<String> = Set(),
             credentialSchema: VerifiableCredentialTypeContainer? = nil,
-            credentialSubject: AnyCodable,
+            credentialSubject: Domain.AnyCodable,
             credentialStatus: JWTRevocationStatus? = nil,
             refreshService: VerifiableCredentialTypeContainer? = nil,
             evidence: VerifiableCredentialTypeContainer? = nil,

--- a/EdgeAgentSDK/Pollux/Sources/Models/SDJWT/SDJWT+ProvableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/SDJWT/SDJWT+ProvableCredential.swift
@@ -6,10 +6,10 @@ extension SDJWTCredential: ProvableCredential {
         guard
             let attachment = request.attachments.first,
             let format = attachment.format,
-            let requestData = request.attachments.first.flatMap({
+            let requestData = try request.attachments.first.flatMap({
                 switch $0.data {
                 case let json as AttachmentJsonData:
-                    return json.data
+                    return try JSONEncoder.didComm().encode(json.json)
                 case let bas64 as AttachmentBase64:
                     return Data(fromBase64URL: bas64.base64)
                 default:

--- a/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential+Codable.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential+Codable.swift
@@ -1,4 +1,3 @@
-import Core
 import Domain
 import Foundation
 

--- a/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/Models/W3C/W3CVerifiableCredential.swift
@@ -11,7 +11,7 @@ struct W3CVerifiableCredential {
     let issuanceDate: Date
     let expirationDate: Date?
     let credentialSchema: VerifiableCredentialTypeContainer?
-    let credentialSubject: AnyCodable
+    let credentialSubject: Domain.AnyCodable
     let credentialStatus: VerifiableCredentialTypeContainer?
     let refreshService: VerifiableCredentialTypeContainer?
     let evidence: VerifiableCredentialTypeContainer?
@@ -30,7 +30,7 @@ struct W3CVerifiableCredential {
         issuanceDate: Date,
         expirationDate: Date? = nil,
         credentialSchema: VerifiableCredentialTypeContainer? = nil,
-        credentialSubject: AnyCodable,
+        credentialSubject: Domain.AnyCodable,
         credentialStatus: VerifiableCredentialTypeContainer? = nil,
         refreshService: VerifiableCredentialTypeContainer? = nil,
         evidence: VerifiableCredentialTypeContainer? = nil,

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialRequest.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialRequest.swift
@@ -21,14 +21,20 @@ extension PolluxImpl {
         case "jwt", "prism/jwt", .none:
             switch offerAttachment.data {
             case let json as AttachmentJsonData:
-                return try await processJWTCredentialRequest(offerData: json.data, options: options)
+                return try await processJWTCredentialRequest(
+                    offerData: try JSONEncoder.didComm().encode(json.json),
+                    options: options
+                )
             default:
                 throw PolluxError.offerDoesntProvideEnoughInformation
             }
         case "vc+sd-jwt":
             switch offerAttachment.data {
             case let json as AttachmentJsonData:
-                return try await processSDJWTCredentialRequest(offerData: json.data, options: options)
+                return try await processSDJWTCredentialRequest(
+                    offerData: try JSONEncoder.didComm().encode(json.json),
+                    options: options
+                )
             default:
                 throw PolluxError.offerDoesntProvideEnoughInformation
             }
@@ -39,7 +45,7 @@ extension PolluxImpl {
                     throw PolluxError.messageDoesntProvideEnoughInformation
                 }
                 return try await processAnoncredsCredentialRequest(
-                    offerData: attachmentData.data,
+                    offerData: try JSONEncoder.didComm().encode(attachmentData.json),
                     thid: thid,
                     options: options
                 )

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialVerification.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+CredentialVerification.swift
@@ -1,5 +1,4 @@
 import AnoncredsSwift
-import Core
 import Domain
 import Foundation
 import JSONWebAlgorithms
@@ -32,7 +31,7 @@ extension PolluxImpl {
             }
             jsonData = decoded
         case let attchedData as AttachmentJsonData:
-            jsonData = attchedData.data
+            jsonData = try JSONEncoder.didComm().encode(attchedData.json)
         default:
             throw PolluxError.invalidAttachmentType(supportedTypes: ["Json", "Base64"])
         }
@@ -102,7 +101,7 @@ extension PolluxImpl {
         let json: Data
         switch attachmentData {
         case let jsonData as AttachmentJsonData:
-            json = jsonData.data
+            json = try JSONEncoder.didComm().encode(jsonData.json)
         case let base64Data as AttachmentBase64:
             json = try base64Data.decoded()
         default:
@@ -173,7 +172,7 @@ extension PolluxImpl {
         let json: Data
         switch attachmentData {
         case let jsonData as AttachmentJsonData:
-            json = jsonData.data
+            json = try JSONEncoder.didComm().encode(jsonData.json)
         case let base64Data as AttachmentBase64:
             guard let data = try Data(fromBase64URL: base64Data.base64.tryToData()) else {
                 throw CommonError.invalidCoding(message: "Could not decode base64 message attchment")

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+ParseCredential.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+ParseCredential.swift
@@ -11,7 +11,9 @@ extension PolluxImpl {
         case "jwt", "", "prism/jwt", .none:
             switch issuedAttachment.data {
             case let json as AttachmentJsonData:
-                return try ParseJWTCredentialFromMessage.parse(issuerCredentialData: json.data)
+                return try ParseJWTCredentialFromMessage.parse(
+                    issuerCredentialData: try JSONEncoder.didComm().encode(json.json)
+                )
             case let base64 as AttachmentBase64:
                 return try ParseJWTCredentialFromMessage.parse(issuerCredentialData: try base64.decoded())
             default:
@@ -20,7 +22,7 @@ extension PolluxImpl {
         case "vc+sd-jwt":
             switch issuedAttachment.data {
             case let json as AttachmentJsonData:
-                return try SDJWTCredential(sdjwtString: json.data.tryToString())
+                return try SDJWTCredential(sdjwtString: JSONEncoder.didComm().encode(json.json).tryToString())
             case let base64 as AttachmentBase64:
                 return try SDJWTCredential(sdjwtString: try base64.decoded().tryToString())
             default:
@@ -63,7 +65,7 @@ extension PolluxImpl {
             switch issuedAttachment.data {
             case let json as AttachmentJsonData:
                 return try await ParseAnoncredsCredentialFromMessage.parse(
-                    issuerCredentialData: json.data,
+                    issuerCredentialData: JSONEncoder.didComm().encode(json.json),
                     linkSecret: linkSecret,
                     credentialDefinitionDownloader: definitionDownloader,
                     schemaDownloader: schemaDownloader,


### PR DESCRIPTION
### Description: 
This PR adds connectionless issuance and replaces the [PR](https://github.com/hyperledger/identus-edge-agent-sdk-swift/pull/163) since it is already with new refactoring so it adds connectionless issuance and presentation.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
