### PR TITLE
fix: removing unneeded async from func

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
@@ -21,8 +21,8 @@ public extension DIDCommAgent {
         fromDID: DID,
         toDID: DID,
         claimFilters: [ClaimFilter]
-    ) async throws -> RequestPresentation {
-        let rqstStr = try await edgeAgent.initiatePresentationRequest(
+    ) throws -> RequestPresentation {
+        let rqstStr = try edgeAgent.initiatePresentationRequest(
             type: type,
             fromDID: fromDID,
             toDID: toDID,

--- a/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Credentials.swift
@@ -38,7 +38,7 @@ public extension EdgeAgent {
         fromDID: DID,
         toDID: DID,
         claimFilters: [ClaimFilter]
-    ) async throws -> String {
+    ) throws -> String {
         let request = try self.pollux.createPresentationRequest(
             type: type,
             toDID: toDID,


### PR DESCRIPTION
### Description: 
There was a func with an unneeded async, removing.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
