### PR TITLE
fix(pluto): Handle write operations inside FlatMap with Future

### DIFF
--- a/EdgeAgentSDK/Pluto/Sources/PersistentStorage/DAO/CDMessageDAO+MessageStore.swift
+++ b/EdgeAgentSDK/Pluto/Sources/PersistentStorage/DAO/CDMessageDAO+MessageStore.swift
@@ -44,11 +44,13 @@ extension CDMessageDAO: MessageStore {
             .first()
             .map { $0.first }
             .flatMap { pair in
-                self.updateOrCreate(
-                    msg.id,
-                    context: writeContext
-                ) { cdobj, _ in
-                    try cdobj.fromDomain(msg: msg, direction: direction, pair: pair)
+                Future {
+                    self.updateOrCreate(
+                        msg.id,
+                        context: writeContext
+                    ) { cdobj, _ in
+                        try cdobj.fromDomain(msg: msg, direction: direction, pair: pair)
+                    }
                 }
             }
             .map { _ in }


### PR DESCRIPTION
### Description: 
[Identus example app](https://github.com/identusbook/example-ios) consistently throws a recursive save error when calling .sendMessage() as described in #183 

Wrapping these .flatMap write operations in a Future seems to fix it in my example.
*note: If this is an acceptable fix, we might need to add another similar Future inside `addMessages()'s .flatMap`

### Alternatives Considered (optional): 
I had tried adding `guard self.hasChanges else { return }` on line 12 of NSManagedObjectContext+Save.swift but that didn't seem to have any effect on this issue.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
