### PR TITLE
feat(agent): the body on issue credential protocol messages can be null

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent+Credentials.swift
@@ -265,8 +265,8 @@ public extension DIDCommAgent {
 
         let requestCredential = RequestCredential3_0(
             body: .init(
-                goalCode: offer.body.goalCode,
-                comment: offer.body.comment
+                goalCode: offer.body?.goalCode,
+                comment: offer.body?.comment
             ),
             type: type.rawValue,
             attachments: [.init(

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/IssueCredential.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/IssueCredential.swift
@@ -29,7 +29,7 @@ public struct IssueCredential {
 
     public let id: String
     public let type: String
-    public let body: Body
+    public let body: Body?
     public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
@@ -37,7 +37,7 @@ public struct IssueCredential {
 
     init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         type: String,
         attachments: [AttachmentDescriptor],
         thid: String?,
@@ -65,7 +65,7 @@ public struct IssueCredential {
             shouldBe: [ProtocolTypes.didcommIssueCredential.rawValue]
         ) }
 
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,
@@ -111,9 +111,9 @@ public struct IssueCredential {
         
         return IssueCredential(
             body: Body(
-                goalCode: request.body.goalCode,
-                comment: request.body.comment,
-                formats: request.body.formats
+                goalCode: request.body?.goalCode,
+                comment: request.body?.comment,
+                formats: request.body?.formats ?? []
             ),
             type: type.rawValue,
             attachments: request.attachments,
@@ -169,7 +169,7 @@ public struct IssueCredential3_0 {
 
     public let id: String
     public let type: String
-    public let body: Body
+    public let body: Body?
     public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
@@ -177,7 +177,7 @@ public struct IssueCredential3_0 {
 
     init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         type: String,
         attachments: [AttachmentDescriptor],
         thid: String?,
@@ -204,7 +204,7 @@ public struct IssueCredential3_0 {
             shouldBe: [ProtocolTypes.didcommIssueCredential3_0.rawValue]
         ) }
 
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,
@@ -247,8 +247,8 @@ public struct IssueCredential3_0 {
         
         return IssueCredential3_0(
             body: Body(
-                goalCode: request.body.goalCode,
-                comment: request.body.comment
+                goalCode: request.body?.goalCode,
+                comment: request.body?.comment
             ),
             type: type.rawValue,
             attachments: request.attachments,

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/OfferCredential.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/OfferCredential.swift
@@ -32,7 +32,7 @@ public struct OfferCredential {
 
     public let id: String
     public let type: String
-    public let body: Body
+    public let body: Body?
     public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
@@ -40,7 +40,7 @@ public struct OfferCredential {
 
     public init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         type: String,
         attachments: [AttachmentDescriptor],
         thid: String?,
@@ -67,10 +67,10 @@ public struct OfferCredential {
             shouldBe: [ProtocolTypes.didcommOfferCredential.rawValue]
         ) }
         
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
-            body: .init(credentialPreview: .init(attributes: []), formats: []), // TODO: [Anoncreds] when they fix on the agent put this back
+            body: body,
             type: piuri.rawValue,
             attachments: fromMessage.attachments,
             thid: fromMessage.thid,
@@ -108,10 +108,10 @@ public struct OfferCredential {
         
         return OfferCredential(
             body: Body(
-                goalCode: proposed.body.goalCode,
-                comment: proposed.body.comment,
-                credentialPreview: proposed.body.credentialPreview,
-                formats: proposed.body.formats
+                goalCode: proposed.body?.goalCode,
+                comment: proposed.body?.comment,
+                credentialPreview: proposed.body?.credentialPreview ?? .init(attributes: []),
+                formats: proposed.body?.formats ?? []
             ),
             type: type.rawValue,
             attachments: proposed.attachments,
@@ -139,14 +139,14 @@ public struct OfferCredential3_0 {
         public let comment: String?
         public let replacementId: String?
         public let multipleAvailable: String?
-        public let credentialPreview: CredentialPreview3_0
+        public let credentialPreview: CredentialPreview3_0?
 
         public init(
             goalCode: String? = nil,
             comment: String? = nil,
             replacementId: String? = nil,
             multipleAvailable: String? = nil,
-            credentialPreview: CredentialPreview3_0
+            credentialPreview: CredentialPreview3_0?
         ) {
             self.goalCode = goalCode
             self.comment = comment
@@ -158,7 +158,7 @@ public struct OfferCredential3_0 {
 
     public let id: String
     public let type: String
-    public let body: Body
+    public let body: Body?
     public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
@@ -166,7 +166,7 @@ public struct OfferCredential3_0 {
 
     public init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         type: String,
         attachments: [AttachmentDescriptor],
         thid: String?,
@@ -193,7 +193,7 @@ public struct OfferCredential3_0 {
             shouldBe: [ProtocolTypes.didcommOfferCredential.rawValue]
         ) }
         
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,
@@ -236,9 +236,9 @@ public struct OfferCredential3_0 {
         
         return OfferCredential3_0(
             body: Body(
-                goalCode: proposed.body.goalCode,
-                comment: proposed.body.comment,
-                credentialPreview: proposed.body.credentialPreview
+                goalCode: proposed.body?.goalCode,
+                comment: proposed.body?.comment,
+                credentialPreview: proposed.body?.credentialPreview
             ),
             type: type.rawValue,
             attachments: proposed.attachments,

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/ProposeCredential.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/ProposeCredential.swift
@@ -5,13 +5,13 @@ import Foundation
 // ALL parameterS are DIDCOMMV2 format and naming conventions and follows the protocol
 // https://github.com/hyperledger/aries-rfcs/tree/main/features/0453-issue-credential-v2
 public struct ProposeCredential {
-    struct Body: Codable, Equatable {
-        let goalCode: String?
-        let comment: String?
-        let credentialPreview: CredentialPreview
-        let formats: [CredentialFormat]
+    public struct Body: Codable, Equatable {
+        public let goalCode: String?
+        public let comment: String?
+        public let credentialPreview: CredentialPreview
+        public let formats: [CredentialFormat]
 
-        init(
+        public init(
             goalCode: String? = nil,
             comment: String? = nil,
             credentialPreview: CredentialPreview,
@@ -26,15 +26,15 @@ public struct ProposeCredential {
 
     public let id: String
     public let type = ProtocolTypes.didcommProposeCredential.rawValue
-    let body: Body
-    let attachments: [AttachmentDescriptor]
+    public let body: Body?
+    public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
     public let to: DID
 
     init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         attachments: [AttachmentDescriptor],
         thid: String?,
         from: DID,
@@ -57,7 +57,7 @@ public struct ProposeCredential {
             type: fromMessage.piuri,
             shouldBe: [ProtocolTypes.didcommProposeCredential.rawValue]
         ) }
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,
@@ -119,15 +119,15 @@ extension ProposeCredential: Equatable {
 // ALL parameterS are DIDCOMMV2 format and naming conventions and follows the protocol
 // https://github.com/hyperledger/aries-rfcs/tree/main/features/0453-issue-credential-v2
 public struct ProposeCredential3_0 {
-    struct Body: Codable, Equatable {
-        let goalCode: String?
-        let comment: String?
-        let credentialPreview: CredentialPreview3_0
+    public struct Body: Codable, Equatable {
+        public let goalCode: String?
+        public let comment: String?
+        public let credentialPreview: CredentialPreview3_0?
 
-        init(
+        public init(
             goalCode: String? = nil,
             comment: String? = nil,
-            credentialPreview: CredentialPreview3_0
+            credentialPreview: CredentialPreview3_0?
         ) {
             self.goalCode = goalCode
             self.comment = comment
@@ -137,15 +137,15 @@ public struct ProposeCredential3_0 {
 
     public let id: String
     public let type = ProtocolTypes.didcommProposeCredential3_0.rawValue
-    let body: Body
-    let attachments: [AttachmentDescriptor]
+    public let body: Body?
+    public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
     public let to: DID
 
     init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         attachments: [AttachmentDescriptor],
         thid: String?,
         from: DID,
@@ -168,7 +168,7 @@ public struct ProposeCredential3_0 {
             type: fromMessage.piuri,
             shouldBe: [ProtocolTypes.didcommProposeCredential3_0.rawValue]
         ) }
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/RequestCredential.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/RequestCredential.swift
@@ -23,7 +23,7 @@ public struct RequestCredential {
 
     public let id: String
     public let type: String
-    public let body: Body
+    public let body: Body?
     public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
@@ -31,7 +31,7 @@ public struct RequestCredential {
 
     init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         type: String,
         attachments: [AttachmentDescriptor],
         thid: String?,
@@ -59,7 +59,7 @@ public struct RequestCredential {
             shouldBe: [ProtocolTypes.didcommRequestCredential.rawValue]
         ) }
 
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,
@@ -103,9 +103,9 @@ public struct RequestCredential {
         
         return RequestCredential(
             body: .init(
-                goalCode: offer.body.goalCode,
-                comment: offer.body.comment,
-                formats: offer.body.formats
+                goalCode: offer.body?.goalCode,
+                comment: offer.body?.comment,
+                formats: offer.body?.formats ?? []
             ),
             type: type.rawValue,
             attachments: offer.attachments,
@@ -144,7 +144,7 @@ public struct RequestCredential3_0 {
 
     public let id: String
     public let type: String
-    public let body: Body
+    public let body: Body?
     public let attachments: [AttachmentDescriptor]
     public let thid: String?
     public let from: DID
@@ -152,7 +152,7 @@ public struct RequestCredential3_0 {
 
     init(
         id: String = UUID().uuidString,
-        body: Body,
+        body: Body?,
         type: String,
         attachments: [AttachmentDescriptor],
         thid: String?,
@@ -179,7 +179,7 @@ public struct RequestCredential3_0 {
             shouldBe: [ProtocolTypes.didcommRequestCredential3_0.rawValue]
         ) }
 
-        let body = try JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
+        let body = try? JSONDecoder.didComm().decode(Body.self, from: fromMessage.body)
         self.init(
             id: fromMessage.id,
             body: body,
@@ -221,8 +221,8 @@ public struct RequestCredential3_0 {
         
         return RequestCredential3_0(
             body: .init(
-                goalCode: offer.body.goalCode,
-                comment: offer.body.comment
+                goalCode: offer.body?.goalCode,
+                comment: offer.body?.comment
             ),
             type: type.rawValue,
             attachments: offer.attachments,

--- a/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/RevocationNotification.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/Protocols/IssueCredential/RevocationNotification.swift
@@ -94,9 +94,9 @@ public struct RevocationNotification {
 
         return RequestCredential(
             body: .init(
-                goalCode: offer.body.goalCode,
-                comment: offer.body.comment,
-                formats: offer.body.formats
+                goalCode: offer.body?.goalCode,
+                comment: offer.body?.comment,
+                formats: offer.body?.formats ?? []
             ),
             type: ProtocolTypes.didcommRevocationNotification.rawValue,
             attachments: offer.attachments,

--- a/EdgeAgentSDK/EdgeAgent/Tests/IssueCredentialTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/IssueCredentialTests.swift
@@ -49,7 +49,7 @@ final class IssueCredentialTests: XCTestCase {
         XCTAssertEqual(validRequestCredential.to, testIssueCredential.from)
         XCTAssertEqual(validRequestCredential.attachments, testIssueCredential.attachments)
         XCTAssertEqual(validRequestCredential.id, testIssueCredential.thid)
-        XCTAssertEqual(validRequestCredential.body.goalCode, validRequestCredential.body.goalCode)
-        XCTAssertEqual(validRequestCredential.body.comment, validRequestCredential.body.comment)
+        XCTAssertEqual(validRequestCredential.body?.goalCode, validRequestCredential.body?.goalCode)
+        XCTAssertEqual(validRequestCredential.body?.comment, validRequestCredential.body?.comment)
     }
 }

--- a/EdgeAgentSDK/EdgeAgent/Tests/RequestCredentialTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/RequestCredentialTests.swift
@@ -58,7 +58,7 @@ final class RequestCredentialTests: XCTestCase {
         XCTAssertEqual(validOfferCredential.to, testRequestCredential.from)
         XCTAssertEqual(validOfferCredential.attachments, testRequestCredential.attachments)
         XCTAssertEqual(validOfferCredential.thid, testRequestCredential.thid)
-        XCTAssertEqual(validOfferCredential.body.goalCode, testRequestCredential.body.goalCode)
-        XCTAssertEqual(validOfferCredential.body.comment, testRequestCredential.body.comment)
+        XCTAssertEqual(validOfferCredential.body?.goalCode, testRequestCredential.body?.goalCode)
+        XCTAssertEqual(validOfferCredential.body?.comment, testRequestCredential.body?.comment)
     }
 }


### PR DESCRIPTION


### Description: 
feat(agent): the body on issue credential protocol messages can be null

(https://github.com/hyperledger/identus/issues/115)

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
